### PR TITLE
Fix: Amélioration de l'affichage du cash-flow avant/après impôt

### DIFF
--- a/css/cashflow-display-fix.css
+++ b/css/cashflow-display-fix.css
@@ -1,0 +1,71 @@
+/* Styles pour l'affichage amélioré du cash-flow */
+
+.cashflow-detailed-wrapper {
+    padding: 0.75rem 0;
+}
+
+.cashflow-label-small {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    opacity: 0.7;
+    margin-bottom: 0.25rem;
+}
+
+.fiscal-impact-box {
+    background: rgba(239, 68, 68, 0.05);
+    border: 1px solid rgba(239, 68, 68, 0.2);
+    border-radius: 6px;
+    padding: 0.75rem;
+    margin: 0.75rem 0;
+}
+
+.fiscal-impact-header {
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+    color: #ef4444;
+    font-size: 0.875rem;
+}
+
+.fiscal-impact-content {
+    font-size: 0.85rem;
+}
+
+.fiscal-line {
+    display: flex;
+    justify-content: space-between;
+    margin: 0.25rem 0;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.fiscal-line.highlight {
+    font-weight: 600;
+    color: #ef4444;
+    padding-top: 0.25rem;
+    border-top: 1px solid rgba(239, 68, 68, 0.2);
+}
+
+.cashflow-after-tax {
+    background: rgba(0, 191, 255, 0.1);
+    border: 1px solid rgba(0, 191, 255, 0.3);
+    border-radius: 8px;
+    padding: 0.75rem;
+    margin-top: 0.5rem;
+    text-align: center;
+}
+
+.cashflow-monthly-large {
+    font-size: 1.25rem;
+    font-weight: 700;
+    margin-bottom: 0.25rem;
+}
+
+.cashflow-after-tax.positive {
+    background: rgba(34, 197, 94, 0.1);
+    border-color: rgba(34, 197, 94, 0.3);
+}
+
+.cashflow-after-tax.negative {
+    background: rgba(239, 68, 68, 0.1);
+    border-color: rgba(239, 68, 68, 0.3);
+}

--- a/simulation-interface-cashflow-fix.js
+++ b/simulation-interface-cashflow-fix.js
@@ -1,0 +1,73 @@
+// Modification partielle - Je vais juste vous montrer les changements clés
+// À insérer dans la fonction afficherResultats() vers la ligne 1800
+
+// Remplacer cette partie du code pour le cash-flow classique :
+// Cash-flow mensuel et annuel
+const cashflowClassique = document.getElementById('classique-cashflow');
+if (cashflowClassique) {
+    // NOUVELLE VERSION : Affichage amélioré avec décomposition
+    const cashflowWrapper = document.createElement('div');
+    cashflowWrapper.className = 'cashflow-detailed-wrapper';
+    
+    // Ajouter label "AVANT impôt"
+    const labelAvant = document.createElement('div');
+    labelAvant.className = 'cashflow-label-small';
+    labelAvant.textContent = 'Cash-flow AVANT impôt';
+    
+    // Cash-flow mensuel avant impôt
+    const cashflowMensuel = document.createElement('div');
+    cashflowMensuel.className = 'cashflow-monthly ' + getClasseValeur(classique.cashFlow);
+    cashflowMensuel.textContent = formaterMontantMensuel(classique.cashFlow);
+    
+    // Cash-flow annuel avant impôt
+    const cashflowAnnuel = document.createElement('div');
+    cashflowAnnuel.className = 'cashflow-annual ' + getClasseValeur(classique.cashFlow);
+    cashflowAnnuel.textContent = formaterMontantAnnuel(classique.cashFlow * 12);
+    
+    // Encadré impact fiscal
+    const fiscalBox = document.createElement('div');
+    fiscalBox.className = 'fiscal-impact-box';
+    fiscalBox.innerHTML = `
+        <div class="fiscal-impact-header">
+            <i class="fas fa-calculator"></i> Impact fiscal
+        </div>
+        <div class="fiscal-impact-content">
+            <div class="fiscal-line">
+                <span>Revenu imposable :</span>
+                <span>${formaterMontant(classique.revenuFoncier || 0)}</span>
+            </div>
+            <div class="fiscal-line">
+                <span>Impôt annuel :</span>
+                <span class="negative">${formaterMontant(classique.impactFiscal || 0)}</span>
+            </div>
+            <div class="fiscal-line highlight">
+                <span>Impact mensuel :</span>
+                <span class="negative">${formaterMontant((classique.impactFiscal || 0) / 12)}/mois</span>
+            </div>
+        </div>
+    `;
+    
+    // Cash-flow APRÈS impôt
+    const cashflowApresImpotMensuel = classique.cashFlow + ((classique.impactFiscal || 0) / 12);
+    const labelApres = document.createElement('div');
+    labelApres.className = 'cashflow-label-small mt-2';
+    labelApres.innerHTML = '<strong>Cash-flow APRÈS impôt</strong>';
+    
+    const cashflowApres = document.createElement('div');
+    cashflowApres.className = 'cashflow-after-tax ' + getClasseValeur(cashflowApresImpotMensuel);
+    cashflowApres.innerHTML = `
+        <div class="cashflow-monthly-large">${formaterMontantMensuel(cashflowApresImpotMensuel)}</div>
+        <div class="cashflow-annual">${formaterMontantAnnuel(cashflowApresImpotMensuel * 12)}</div>
+    `;
+    
+    // Assembler le tout
+    cashflowWrapper.appendChild(labelAvant);
+    cashflowWrapper.appendChild(cashflowMensuel);
+    cashflowWrapper.appendChild(cashflowAnnuel);
+    cashflowWrapper.appendChild(fiscalBox);
+    cashflowWrapper.appendChild(labelApres);
+    cashflowWrapper.appendChild(cashflowApres);
+    
+    // Remplacer l'ancien affichage
+    cashflowClassique.parentNode.replaceChild(cashflowWrapper, cashflowClassique);
+}


### PR DESCRIPTION
## Amélioration de l'affichage du cash-flow

### Problème résolu
L'affichage actuel prête à confusion car il n'est pas clair que le cash-flow affiché est avant impôt, et l'impact fiscal est affiché séparément.

### Solution implémentée
1. **Séparation claire** : Cash-flow AVANT impôt clairement identifié
2. **Encadré fiscal** : Détail de l'impact fiscal (revenu imposable, impôt annuel, impact mensuel)
3. **Résultat final mis en évidence** : Cash-flow APRÈS impôt dans un encadré coloré

### Fichiers créés
- `simulation-interface-cashflow-fix.js` : Exemple de code à intégrer dans la fonction `afficherResultats()`
- `css/cashflow-display-fix.css` : Styles CSS à ajouter à `immo-enhanced.css`

### Aperçu visuel
Le nouveau affichage montre :
```
Cash-flow AVANT impôt
-371 €/mois
-4 457 €/an

📊 Impact fiscal
Revenu imposable : 6 418 €
Impôt annuel : -3 029 €
Impact mensuel : -252 €/mois

Cash-flow APRÈS impôt
-623 €/mois
-7 476 €/an
```

### Prochaines étapes
1. Intégrer le code dans `simulation-interface.js` (remplacer la section cash-flow)
2. Ajouter les styles CSS dans `css/immo-enhanced.css`
3. Faire la même modification pour les enchères