### PR TITLE
Fix: Réintégration CSG/CRDS non déductible pour les dirigeants TNS

### DIFF
--- a/docs/fix-csg-crds-tns.md
+++ b/docs/fix-csg-crds-tns.md
@@ -1,0 +1,93 @@
+# Correctif CSG/CRDS pour les dirigeants TNS
+
+## 🐛 Description du problème
+
+Pour les dirigeants TNS (Travailleurs Non Salariés) des structures suivantes :
+- **EURL à l'IS**
+- **SARL** (gérant majoritaire)
+- **SELARL**
+- **SCA**
+
+La CSG/CRDS non déductible (2,9% de la rémunération brute) n'est pas réintégrée dans la base imposable pour le calcul de l'impôt sur le revenu.
+
+## 📊 Impact financier
+
+### Exemple concret :
+- Chiffre d'affaires : 4 000 000€
+- Marge : 99% → Résultat : 3 960 000€
+- Rémunération (70%) : 2 772 000€
+- Cotisations TNS (30%) : 831 600€
+- **Revenu net social** : 1 940 400€
+
+### Erreur actuelle :
+- L'IR est calculé sur : 1 940 400€ ❌
+
+### Calcul correct :
+- CSG/CRDS non déductible : 2 772 000€ × 2,9% = **80 388€**
+- Base imposable IR : 1 940 400€ + 80 388€ = **2 020 788€** ✅
+
+### Conséquences :
+- Sous-estimation de l'impôt de plusieurs dizaines de milliers d'euros
+- Comparaisons faussées entre statuts juridiques
+- Risque de redressement fiscal pour les utilisateurs
+
+## 🔧 Solution technique
+
+### 1. Identifier la CSG non déductible
+```javascript
+const CSG_CRDS_IMPOSABLE = 0.029; // 2,9%
+const csgNonDeductible = Math.round(remuneration * CSG_CRDS_IMPOSABLE);
+```
+
+### 2. Réintégrer dans la base imposable
+```javascript
+const baseImposableIR = remunerationNetteSociale + csgNonDeductible;
+```
+
+### 3. Calculer l'IR sur la base correcte
+```javascript
+const impotRevenu = modeExpert 
+    ? FiscalUtils.calculateProgressiveIR(baseImposableIR)
+    : Math.round(baseImposableIR * tmiActuel / 100);
+```
+
+## 📝 Fichiers à modifier
+
+1. **fiscal-simulation.js** :
+   - Méthode `simulerEURL` (section IS)
+   - Méthode `simulerSARL` (condition gérant majoritaire)
+   - Méthode `simulerSELARL`
+   - Méthode `simulerSCA`
+
+2. **fiscal-guide.js** :
+   - Fonction `showCalculationDetails` pour afficher la réintégration CSG
+
+## ✅ Tests de validation
+
+Exécuter dans la console :
+```javascript
+// Test avec CA 4M€, marge 99%, rémunération 70%
+const resultat = window.SimulationsFiscales.simulerEURL({
+    ca: 4000000,
+    tauxMarge: 0.99,
+    tauxRemuneration: 0.70,
+    optionIS: true,
+    modeExpert: true
+});
+
+console.log("CSG non déductible:", resultat.csgNonDeductible); // Doit être ~80 388€
+console.log("Base imposable IR:", resultat.baseImposableIR); // Doit être ~2 020 788€
+```
+
+## 🚀 Prochaines étapes
+
+1. Appliquer les modifications dans fiscal-simulation.js
+2. Mettre à jour l'affichage des détails dans fiscal-guide.js
+3. Tester sur tous les statuts TNS concernés
+4. Vérifier l'impact sur les simulations existantes
+
+## 📚 Références
+
+- [Article 154 quinquies du CGI](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000041471314) - CSG/CRDS déductible
+- Taux CSG/CRDS non déductible : 2,4% (CSG) + 0,5% (CRDS) = 2,9%
+- Applicable aux revenus d'activité des TNS

--- a/js/patches/patch-csg-crds-tns.js
+++ b/js/patches/patch-csg-crds-tns.js
@@ -1,0 +1,83 @@
+// patch-csg-crds-tns.js - Correctif pour la réintégration CSG/CRDS non déductible des TNS
+// Ce fichier contient les modifications à appliquer dans fiscal-simulation.js
+
+// IMPORTANT: Ces modifications doivent être intégrées dans fiscal-simulation.js
+// pour corriger le calcul de l'impôt sur le revenu des dirigeants TNS
+
+/*
+PROBLÈME IDENTIFIÉ:
+Pour les dirigeants TNS (EURL IS, SARL gérant majoritaire, SELARL, SCA),
+la CSG/CRDS non déductible (2,9% de la rémunération brute) n'est pas réintégrée
+dans la base imposable pour le calcul de l'impôt sur le revenu.
+
+IMPACT:
+- L'IR est sous-estimé car calculé sur une base trop faible
+- Pour une rémunération de 2.77M€, cela représente 80k€ de base imposable manquante
+- L'erreur peut représenter plusieurs dizaines de milliers d'euros d'impôt
+
+SOLUTION:
+Réintégrer systématiquement la CSG/CRDS non déductible dans la base imposable
+pour tous les statuts TNS avant le calcul de l'IR.
+*/
+
+// Exemple de correction pour la méthode simulerEURL (à adapter pour IS = true)
+// Dans la section EURL à l'IS :
+
+/*
+// Calcul des cotisations TNS
+const cotisationsSociales = FiscalUtils.calculCotisationsTNS(remuneration);
+const remunerationNetteSociale = remuneration - cotisationsSociales;
+
+// AJOUT CRITIQUE: Réintégration CSG/CRDS non déductible
+const csgNonDeductible = Math.round(remuneration * CSG_CRDS_IMPOSABLE); // 2.9%
+const baseImposableIR = remunerationNetteSociale + csgNonDeductible;
+
+// Calcul de l'IR sur la BASE IMPOSABLE (et non sur le net social)
+const impotRevenu = modeExpert 
+    ? FiscalUtils.calculateProgressiveIR(baseImposableIR)
+    : Math.round(baseImposableIR * tmiActuel / 100);
+*/
+
+// Modifications similaires nécessaires pour:
+// - simulerSARL (quand gerantMajoritaire = true)
+// - simulerSELARL
+// - simulerSCA
+
+// Dans le retour de chaque fonction, ajouter:
+/*
+return {
+    // ... propriétés existantes ...
+    csgNonDeductible,      // Nouveau: montant CSG non déductible
+    baseImposableIR,       // Nouveau: base imposable incluant CSG
+    // ... autres propriétés ...
+};
+*/
+
+// TESTS DE VALIDATION
+function validateCSGIntegration() {
+    const testCases = [
+        {
+            statut: 'EURL IS',
+            remuneration: 2772000,
+            expected: {
+                cotisationsTNS: 831600,
+                revenuNetSocial: 1940400,
+                csgNonDeductible: 80388,
+                baseImposableIR: 2020788
+            }
+        }
+    ];
+    
+    console.log("Validation de l'intégration CSG/CRDS:");
+    testCases.forEach(test => {
+        console.log(`\n${test.statut}:`);
+        console.log(`- Rémunération: ${test.remuneration.toLocaleString()}€`);
+        console.log(`- CSG non déductible attendue: ${test.expected.csgNonDeductible.toLocaleString()}€`);
+        console.log(`- Base imposable attendue: ${test.expected.baseImposableIR.toLocaleString()}€`);
+    });
+}
+
+// Export pour référence
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { validateCSGIntegration };
+}


### PR DESCRIPTION
## 🐛 Correction critique : Réintégration CSG/CRDS non déductible pour les TNS

### Problème identifié
Pour les dirigeants TNS (EURL IS, SARL gérant majoritaire, SELARL, SCA), la CSG/CRDS non déductible (2,9% de la rémunération brute) n'est pas réintégrée dans la base imposable pour le calcul de l'impôt sur le revenu.

### Impact
- **Sous-estimation de l'impôt** : L'IR est calculé sur une base trop faible
- **Exemple concret** : Pour une rémunération de 2,77M€, cela représente 80k€ de base imposable manquante
- **Conséquence financière** : Plusieurs dizaines de milliers d'euros d'impôt sous-estimés

### Solution proposée
1. Calculer la CSG/CRDS non déductible : `remuneration × 2,9%`
2. L'ajouter au revenu net social pour obtenir la base imposable IR
3. Calculer l'IR sur cette base corrigée

### Fichiers créés
- `js/patches/patch-csg-crds-tns.js` : Code de correction à intégrer
- `docs/fix-csg-crds-tns.md` : Documentation détaillée du problème et de la solution

### Test de validation
```javascript
// Avec CA 4M€, marge 99%, rémunération 70%
// Attendu : Base imposable = 2 020 788€ (et non 1 940 400€)
```

### Prochaines étapes
Les modifications doivent être intégrées dans `fiscal-simulation.js` pour les méthodes :
- `simulerEURL` (section IS)
- `simulerSARL` (gérant majoritaire)
- `simulerSELARL`
- `simulerSCA`

---
⚠️ **Cette correction est critique pour la fiabilité des simulations fiscales**